### PR TITLE
Allow to use httpoison 0.9.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Sms.Mixfile do
   defp deps do
     [
      {:poison, "~> 1.5", override: true},
-     {:httpoison, "~> 0.8.1"}
+     {:httpoison, "~> 0.8"}
     ]
   end
 end


### PR DESCRIPTION
```
Failed to use "httpoison" (version 0.9.0) because
  deps/sms/mix.exs requires ~> 0.8.1
```
